### PR TITLE
Arbitrary Read/Write detection refactoring

### DIFF
--- a/analysis/breakpoints.py
+++ b/analysis/breakpoints.py
@@ -22,8 +22,9 @@ def b_mem_read(state: angr.SimState):
     target_base = utils.get_base_address(state.inspect.mem_read_address)
     utils.print_debug(f'mem_read {state}, {state.inspect.mem_read_address}, {target_base}, {state.inspect.mem_read_expr}, {state.inspect.mem_read_length}, {state.inspect.mem_read_condition}')
 
-    utils.check_npd_vuln(state, state.inspect.mem_read_address, False)
-    utils.check_arw_vuln(state, state.inspect.mem_read_address, False)
+    # First we check for an ARW vulnerability. If we cannot find one there, we check for NPD
+    if not utils.check_arw_vuln(state, state.inspect.mem_read_address, False):
+        utils.check_npd_vuln(state, state.inspect.mem_read_address, False)
     
     # If we are reading at an offset of a user-provided buffer, we need to one-time create a symbolic space that represents that space
     # In this way we can later see if we are reading from an address obtained by dereferencing this space (a tainted address)
@@ -34,8 +35,9 @@ def b_mem_write(state: angr.SimState):
     target_base = utils.get_base_address(state.inspect.mem_write_address)
     utils.print_debug(f'mem_write {state}, {state.inspect.mem_write_address}, {target_base}, {state.inspect.mem_write_expr}, {state.inspect.mem_write_length}, {state.inspect.mem_write_condition}')
 
-    utils.check_npd_vuln(state, state.inspect.mem_write_address, True)
-    utils.check_arw_vuln(state, state.inspect.mem_write_address, True)
+    # First we check for an ARW vulnerability. If we cannot find one there, we check for NPD
+    if not utils.check_arw_vuln(state, state.inspect.mem_write_address, True):
+        utils.check_npd_vuln(state, state.inspect.mem_write_address, True)
     
     # Same as b_mem_read prologue
     if utils.tainted_buffer(target_base):

--- a/analysis/breakpoints.py
+++ b/analysis/breakpoints.py
@@ -18,117 +18,28 @@ def b_mem_write_DriverStartIo(state):
     globals.basic_info['DriverStartIo'] = hex(globals.DriverStartIo)
     utils.print_info(f'DriverStartIo: {hex(globals.DriverStartIo)}')
 
-def b_mem_read(state):
-    utils.print_debug(f'mem_read {state}, {state.inspect.mem_read_address}, {state.inspect.mem_read_expr}, {state.inspect.mem_read_length}, {state.inspect.mem_read_condition}')
+def b_mem_read(state: angr.SimState):
+    target_base = utils.get_base_address(state.inspect.mem_read_address)
+    utils.print_debug(f'mem_read {state}, {state.inspect.mem_read_address}, {target_base}, {state.inspect.mem_read_expr}, {state.inspect.mem_read_length}, {state.inspect.mem_read_condition}')
+
+    utils.check_npd_vuln(state, state.inspect.mem_read_address, False)
+    utils.check_arw_vuln(state, state.inspect.mem_read_address, False)
     
-    # Iterate all target buffers.
-    for target in globals.NPD_TARGETS:
-        if target in str(state.inspect.mem_read_address):
-            asts = [i for i in state.inspect.mem_read_address.children_asts()]
-            target_base = asts[0] if len(asts) > 1 else state.inspect.mem_read_address
-            vars = state.inspect.mem_read_address.variables
+    # If we are reading at an offset of a user-provided buffer, we need to one-time create a symbolic space that represents that space
+    # In this way we can later see if we are reading from an address obtained by dereferencing this space (a tainted address)
+    if utils.tainted_buffer(target_base):
+        utils.symbolyze_buffer(state, target_base)
 
-            if str(target_base) not in state.globals['tainted_ProbeForRead'] and str(target_base) not in state.globals['tainted_ProbeForWrite'] and len(vars) == 1:
-                # Add constraints to test whether the pointer is null or not.
-                tmp_state = state.copy()
-                if target == 'SystemBuffer':
-                    if '*' in str(state.inspect.mem_read_address):
-                        # If SystemBuffer is a pointer, check whether it is controllable.
-                        tmp_state.solver.add(tmp_state.inspect.mem_read_address == 0x87)
-                        if tmp_state.satisfiable() and not str(target_base) in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('read/write controllable address', 'read', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                    else:
-                        # If SystemBuffer is not a pointer, check whether it can be null.
-                        tmp_state.solver.add(globals.SystemBuffer == 0)
-                        tmp_state.solver.add(globals.InputBufferLength == 0)
-                        tmp_state.solver.add(globals.OutputBufferLength == 0)
-                        if tmp_state.satisfiable() and str(target_base) not in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('null pointer dereference - input buffer', 'read input buffer', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                elif target == 'Type3InputBuffer' or target == 'UserBuffer':
-                    # If Type3InputBuffer or UserBuffer is a pointer, check whether it is controllable.
-                    if target == 'Type3InputBuffer':
-                        tmp_state.solver.add(globals.Type3InputBuffer == 0x87)
-                    elif target == 'UserBuffer':
-                        tmp_state.solver.add(globals.UserBuffer == 0x87)
+def b_mem_write(state: angr.SimState):
+    target_base = utils.get_base_address(state.inspect.mem_write_address)
+    utils.print_debug(f'mem_write {state}, {state.inspect.mem_write_address}, {target_base}, {state.inspect.mem_write_expr}, {state.inspect.mem_write_length}, {state.inspect.mem_write_condition}')
 
-                    if tmp_state.satisfiable() and not str(target_base) in state.globals['tainted_MmIsAddressValid']:
-                        utils.print_vuln('read/write controllable address', 'read', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                else:
-                    # Only detect the allocated memory in case of false positive.
-                    if '+' in str(tmp_state.inspect.mem_read_address):
-                        return
-                    tmp_state.solver.add(tmp_state.inspect.mem_read_address == 0)
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('null pointer dereference - allocated memory', 'read allocated memory', state, {}, {'read from': str(state.inspect.mem_read_address)})
-
-            # We symbolize the address of the tainted buffer because we want to detect the vulnerability when the driver reads/writes to/from the buffer.
-            if utils.tainted_buffer(target_base) and str(target_base) not in state.globals:
-                tmp_state = state.copy()
-                tmp_state.solver.add(target_base == globals.FIRST_ADDR)
-                if not tmp_state.satisfiable():
-                    break
-
-                state.globals[str(target_base)] = True
-                mem = claripy.BVS(f'*{str(target_base)}', 8 * 0x200).reversed
-                addr = utils.next_base_addr()
-                state.solver.add(target_base == addr)
-                state.memory.store(addr, mem, 0x200, disable_actions=True, inspect=False)
-
-def b_mem_write(state):
-    utils.print_debug(f'mem_write {state}, {state.inspect.mem_write_address}, {state.inspect.mem_write_expr}, {state.inspect.mem_write_length}, {state.inspect.mem_write_condition}')
-
-    # Iterate all target buffers.
-    for target in globals.NPD_TARGETS:
-        if target in str(state.inspect.mem_write_address):
-            asts = [i for i in state.inspect.mem_write_address.children_asts()]
-            target_base = asts[0] if len(asts) > 1 else state.inspect.mem_write_address
-            vars = state.inspect.mem_write_address.variables
-
-            if str(target_base) not in state.globals['tainted_ProbeForRead'] and str(target_base) not in state.globals['tainted_ProbeForWrite'] and len(vars) == 1:
-                # Add constraints to test whether the pointer is null or not.
-                tmp_state = state.copy()
-                if target == 'SystemBuffer':
-                    if '*' in str(state.inspect.mem_write_address):
-                        # If SystemBuffer is a pointer, check whether it is controllable.
-                        tmp_state.solver.add(tmp_state.inspect.mem_write_address == 0x87)
-                        if tmp_state.satisfiable():
-                            utils.print_vuln('read/write controllable address', 'write', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                    else:
-                        # If SystemBuffer is not a pointer, check whether it can be null.
-                        tmp_state.solver.add(globals.SystemBuffer == 0)
-                        tmp_state.solver.add(globals.InputBufferLength == 0)
-                        tmp_state.solver.add(globals.OutputBufferLength == 0)
-                        if tmp_state.satisfiable() and str(target_base) not in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('null pointer dereference - input buffer', 'write input buffer', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                elif target == 'Type3InputBuffer' or target == 'UserBuffer':
-                    # If Type3InputBuffer or UserBuffer is a pointer, check whether it is controllable.
-                    if target == 'Type3InputBuffer':
-                        tmp_state.solver.add(globals.Type3InputBuffer == 0x87)
-                    elif target == 'UserBuffer':
-                        tmp_state.solver.add(globals.UserBuffer == 0x87)
-
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('read/write controllable address', 'write', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                else:
-                    # Only detect the allocated memory in case of false positive.
-                    if '+' in str(tmp_state.inspect.mem_write_address):
-                        return
-                    tmp_state.solver.add(tmp_state.inspect.mem_write_address == 0)
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('null pointer dereference - allocated memory', 'write allocated memory', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                
-            # We symbolize the address of the tainted buffer because we want to detect the vulnerability when the driver reads/writes to/from the buffer.
-            if utils.tainted_buffer(target_base) and str(target_base) not in state.globals:
-                tmp_state = state.copy()
-                tmp_state.solver.add(target_base == globals.FIRST_ADDR)
-                if not tmp_state.satisfiable():
-                    break
-                
-                state.globals[str(target_base)] = True
-                mem = claripy.BVS(f'*{str(target_base)}', 8 * 0x200).reversed
-                addr = utils.next_base_addr()
-                state.solver.add(target_base == addr)
-                state.memory.store(addr, mem, 0x200, disable_actions=True, inspect=False)
+    utils.check_npd_vuln(state, state.inspect.mem_write_address, True)
+    utils.check_arw_vuln(state, state.inspect.mem_write_address, True)
+    
+    # Same as b_mem_read prologue
+    if utils.tainted_buffer(target_base):
+        utils.symbolyze_buffer(state, target_base)
 
 def b_address_concretization_before(state):
     utils.print_debug(f'address_concretization_before_hook: {state}\n\taddress_concretization_strategy: {state.inspect.address_concretization_strategy}\n\taddress_concretization_action: {state.inspect.address_concretization_action}\n\taddress_concretization_memory: {state.inspect.address_concretization_memory}\n\taddress_concretization_expr: {state.inspect.address_concretization_expr}\n\taddress_concretization_add_constraints: {state.inspect.address_concretization_add_constraints}\n\taddress_concretization_result: {state.inspect.address_concretization_result}\n')

--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -191,32 +191,22 @@ class HookProbeForRead(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForRead.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if 'tainted_ProbeForRead' in self.state.globals and utils.tainted_buffer(Address):
-                asts = [i for i in Address.children_asts()]
-                target_base = asts[0] if len(asts) > 1 else Address
-
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_ProbeForRead'] += (str(target_base), )
+            if ('tainted_ProbeForRead' in self.state.globals) and utils.user_memory_address(self.state, Address):
+                self.state.globals['tainted_ProbeForRead'] += (str(Address), )
 
 class HookProbeForWrite(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForWrite.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if 'tainted_ProbeForWrite' in self.state.globals and utils.tainted_buffer(Address):
-                asts = [i for i in Address.recursive_children_asts]
-                target_base = asts[0] if len(asts) > 1 else Address
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_ProbeForWrite'] += (str(target_base), )
+            if ('tainted_ProbeForWrite' in self.state.globals) and utils.user_memory_address(self.state, Address):
+                self.state.globals['tainted_ProbeForWrite'] += (str(Address), )
 
 class HookMmIsAddressValid(angr.SimProcedure):
     # Tag the tainted buffer that is validated with MmIsAddressValid.
     def run(self, VirtualAddress):
         if globals.phase == 2:
-            if 'tainted_MmIsAddressValid' in self.state.globals and utils.tainted_buffer(VirtualAddress):
-                asts = [i for i in VirtualAddress.recursive_children_asts]
-                target_base = asts[0] if len(asts) > 1 else VirtualAddress
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_MmIsAddressValid'] += (str(target_base), )
+            if ('tainted_MmIsAddressValid' in self.state.globals) and utils.user_memory_address(self.state, VirtualAddress):
+                self.state.globals['tainted_MmIsAddressValid'] += (str(VirtualAddress), )
         return 1
 
 class HookZwOpenSection(angr.SimProcedure):

--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -191,22 +191,25 @@ class HookProbeForRead(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForRead.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if ('tainted_ProbeForRead' in self.state.globals) and utils.user_memory_address(self.state, Address):
-                self.state.globals['tainted_ProbeForRead'] += (str(Address), )
+            base_address = utils.get_base_address(Address)
+            if ('tainted_ProbeForRead' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_ProbeForRead'] += (str(base_address), )
 
 class HookProbeForWrite(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForWrite.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if ('tainted_ProbeForWrite' in self.state.globals) and utils.user_memory_address(self.state, Address):
-                self.state.globals['tainted_ProbeForWrite'] += (str(Address), )
+            base_address = utils.get_base_address(Address)
+            if ('tainted_ProbeForWrite' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_ProbeForWrite'] += (str(base_address), )
 
 class HookMmIsAddressValid(angr.SimProcedure):
     # Tag the tainted buffer that is validated with MmIsAddressValid.
     def run(self, VirtualAddress):
         if globals.phase == 2:
-            if ('tainted_MmIsAddressValid' in self.state.globals) and utils.user_memory_address(self.state, VirtualAddress):
-                self.state.globals['tainted_MmIsAddressValid'] += (str(VirtualAddress), )
+            base_address = utils.get_base_address(VirtualAddress)
+            if ('tainted_MmIsAddressValid' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_MmIsAddressValid'] += (str(base_address), )
         return 1
 
 class HookZwOpenSection(angr.SimProcedure):
@@ -447,16 +450,9 @@ class HookZwTerminateProcess(angr.SimProcedure):
 class HookMemcpy(angr.SimProcedure):
     def run(self, dest, src, size):
         ret_addr = hex(self.state.callstack.ret_addr)
-        dest_asts = [i for i in dest.children_asts()]
-        dest_base = dest_asts[0] if len(dest_asts) > 1 else dest
-        dest_vars = dest.variables
-
-        src_asts = [i for i in src.children_asts()]
-        src_base = src_asts[0] if len(src_asts) > 1 else src
-        src_vars = src.variables
 
         # Check whether the src or dest address can be controlled.
-        if ('*' in str(dest) and utils.tainted_buffer(dest) and str(dest_base) not in self.state.globals['tainted_ProbeForWrite'] and len(dest_vars) == 1) or ('*' in str(src) and utils.tainted_buffer(src) and str(src_base) not in self.state.globals['tainted_ProbeForRead'] and len(src_vars) == 1):
+        if utils.tainted_memory_address(self.state, dest) or utils.tainted_memory_address(self.state, src):
             utils.print_vuln('dest or src controllable', 'memcpy/memmove', self.state, {'dest': str(dest), 'src': str(src), 'size': str(size)}, {'return address': ret_addr})
 
         # Buffer overflow detected if the size can be controlled and the destination address is not symbolic to avoid false positive.

--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -246,7 +246,7 @@ class HookRtlInitUnicodeString(angr.SimProcedure):
         self.state.memory.store(new_buffer, string_orig, byte_length, disable_actions=True, inspect=False)
         unistr = self.state.mem[DestinationString].struct._UNICODE_STRING
         self.state.memory.store(DestinationString, claripy.BVV(0, unistr._type.size), unistr._type.size // 8, disable_actions=True, inspect=False)
-        unistr.Length = byte_length - 2
+        unistr.Length = byte_length
         unistr.MaximumLength = byte_length
         unistr.Buffer = new_buffer
 

--- a/analysis/ioctlance.py
+++ b/analysis/ioctlance.py
@@ -158,6 +158,8 @@ def hunting(driver_base_state: angr.SimState, ioctl_handler_addr):
     driver_base_state.globals['tainted_ProbeForRead'] = ()
     driver_base_state.globals['tainted_ProbeForWrite'] = ()
     driver_base_state.globals['tainted_MmIsAddressValid'] = ()
+    driver_base_state.globals['tainted_MmProbeAndLockPages'] = ()
+    driver_base_state.globals['tainted_mdls'] = {}
     driver_base_state.globals['tainted_eprocess'] = ()
     driver_base_state.globals['tainted_handles'] = ()
     driver_base_state.globals['tainted_objects'] = ()
@@ -453,6 +455,8 @@ def analyze_driver(driver_path):
     globals.proj.hook_symbol("MmAllocateContiguousMemorySpecifyCache", hooks.HookMmAllocateContiguousMemorySpecifyCache(cc=globals.mycc))
     globals.proj.hook_symbol('MmMapIoSpace', hooks.HookMmMapIoSpace(cc=globals.mycc))
     globals.proj.hook_symbol('MmMapIoSpaceEx', hooks.HookMmMapIoSpaceEx(cc=globals.mycc))
+    globals.proj.hook_symbol('IoAllocateMdl', hooks.HookIoAllocateMdl(cc=globals.mycc))
+    globals.proj.hook_symbol('MmProbeAndLockPages', hooks.HookMmProbeAndLockPages(cc=globals.mycc))
     globals.proj.hook_symbol('HalTranslateBusAddress', hooks.HookHalTranslateBusAddress(cc=globals.mycc))
     globals.proj.hook_symbol('ZwMapViewOfSection', hooks.HookZwMapViewOfSection(cc=globals.mycc))
     globals.proj.hook_symbol('ZwOpenProcess', hooks.HookZwOpenProcess(cc=globals.mycc))

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -59,7 +59,8 @@ def tainted_memory_address(state: angr.SimState, address) -> bool:
     
     # Let's just check if the address has not been probed
     if ((base_str in state.globals['tainted_ProbeForWrite']) or 
-        (base_str in state.globals['tainted_ProbeForRead'])):
+        (base_str in state.globals['tainted_ProbeForRead']) or
+        (base_str in state.globals['tainted_MmProbeAndLockPages'])):
         return False
 
     return True


### PR DESCRIPTION
## PR Overview
We would like to propose a refactoring/enhancement for the arbitrary read/write detection feature. We discovered that the current implementation of ioctlance incorrectly tags some reads and writes as vulnerable whereas instead they should be treated as "null dereferences".

### nvflash.sys
To give you an example, if we run
`python3 analysis/ioctlance.py -i 0x81de804f -o ../LOLDrivers/drivers/1e1a3d43bd598b231207ff3e70f78454.bin` to check [nvflash.sys](https://www.virustotal.com/gui/file/1e1a3d43bd598b231207ff3e70f78454) from the LOLDrivers repo, we obtain:

```json
{
    "title": "read/write controllable address",
    "description": "read",
    "state": "<SimState @ 0x11446>",
    "eval": {
        "IoControlCode": "0x81de804f",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x0",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x0",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "read from": "<BV64 Type3InputBuffer_13_64>"
    }
} 
```

For our understanding, this should not be considered a vulnerability: the driver is expected to directly read from and write to the IOCTL buffer. What we expect, and hence the proposed modification to ioctlance, is this result:

```json
{
    "title": "null pointer dereference - input buffer",
    "description": "read input buffer",
    "state": "<SimState @ 0x11446>",
    "eval": {
        "IoControlCode": "0x81de804f",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x0",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x0",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "read from": "<BV64 Type3InputBuffer_13_64>"
    }
} 
```
In this case, ioctlance should only emit a message if there is the possibility of a null dereference from an input buffer read.

### RwDrv.sys

With the command `python3 analysis/ioctlance.py -i 0x222808 -o ../LOLDrivers/drivers/31469f1313871690e8dc2e8ee4799b22.bin`, both versions of ioctlance output an expected message: the driver is writing to an address passed in the IOCTL buffer.
```
{
    "title": "read/write controllable address",
    "description": "write",
    "state": "<SimState @ 0x11254>",
    "eval": {
        "IoControlCode": "0x222808",
        "SystemBuffer": "0x44560000",
        "Type3InputBuffer": "0x0",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x0",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "write to": "<BV64 *<BV64 SystemBuffer_15_64>_26_4096[191:128]>"
    }
} 
```

### ElbyCDIO.sys

We also noticed that with the proposed modification, we should be able to identify previously missed vulnerabilities. By executing `python3 analysis/ioctlance.py -i 0x22e043 -o ../LOLDrivers/drivers/978cd6d9666627842340ef774fd9e2ac.bin`, ioctlance only reports:
```json

{
    "title": "read/write controllable address",
    "description": "read",
    "state": "<SimState @ 0x119bf>",
    "eval": {
        "IoControlCode": "0x22e043",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x0",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x8",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "read from": "<BV64 Type3InputBuffer_50_64>"
    }
} 
```
With our modification, ioctlance now reports:
```json
{
    "title": "null pointer dereference - input buffer",
    "description": "read input buffer",
    "state": "<SimState @ 0x119bf>",
    "eval": {
        "IoControlCode": "0x22e043",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x0",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x8",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "read from": "<BV64 Type3InputBuffer_50_64>"
    }
} 

{
    "title": "read/write controllable address",
    "description": "read",
    "state": "<SimState @ 0x119d2>",
    "eval": {
        "IoControlCode": "0x22e043",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x44560000",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x8",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "read from": "<BV64 *<BV64 Type3InputBuffer_50_64>_58_4096[63:0] + 0x20>"
    }
} 

{
    "title": "read/write controllable address",
    "description": "write",
    "state": "<SimState @ 0x119e3>",
    "eval": {
        "IoControlCode": "0x22e043",
        "SystemBuffer": "0x0",
        "Type3InputBuffer": "0x44560000",
        "UserBuffer": "0x0",
        "InputBufferLength": "0x8",
        "OutputBufferLength": "0x0"
    },
    "parameters": {},
    "others": {
        "write to": "<BV64 *<BV4096 *<BV64 Type3InputBuffer_50_64>_58_4096>_59_4096[63:0] + 0x8>"
    }
} 
```

Reversed code of the driver should confirm the findings
```
...
case 0x22E043u:
      if ( InputBufferLength < 8 )
        goto LABEL_45;
      v9 = *(BYTE **)CurrentStackLocation->Parameters.DeviceIoControl.Type3InputBuffer;
      KeWaitForSingleObject(&DeviceExtension[1], Executive, 0, 0, 0LL);
      ObfDereferenceObject(*((PVOID *)v9 + 4));
      *(_QWORD *)(*(_QWORD *)v9 + 8LL) = *((_QWORD *)v9 + 1);
      **((_QWORD **)v9 + 1) = *(_QWORD *)v9;
      ExFreePool(v9);
      KeReleaseMutex(DeviceExtension + 1, 0);
      Status = 0;
...
```
## Code modifications
We rewrote `b_mem_read` and `b_mem_write` to share the majority of the code. In our tests, the old `tmp_state.solver.add(globals.UserBuffer == 0x87)` check on arbitrary read/writes was the cause of the missed events, so in utils.check_arw_vuln we opted for a larger value.

We also created a shared function `utils.get_base_address()` for the target address calculation. We believe that `address.leaf_asts()` is a better replacement for recursive_children_asts since it correctly returns the single leaf items of a symbolic expression, whereas recursive_children_asts also returns offsets and other terms