### PR TITLE
Fixed unicode string length calculation in RtlInitUnicodeString

### DIFF
--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -256,7 +256,7 @@ class HookRtlInitUnicodeString(angr.SimProcedure):
         self.state.memory.store(new_buffer, string_orig, byte_length, disable_actions=True, inspect=False)
         unistr = self.state.mem[DestinationString].struct._UNICODE_STRING
         self.state.memory.store(DestinationString, claripy.BVV(0, unistr._type.size), unistr._type.size // 8, disable_actions=True, inspect=False)
-        unistr.Length = byte_length - 2
+        unistr.Length = byte_length
         unistr.MaximumLength = byte_length
         unistr.Buffer = new_buffer
 


### PR DESCRIPTION
From #9 

Last letter is missing in some device names and symbolic links. `HookRtlInitUnicodeString` is creating a `UNICODE_STRING` by setting the `Length` field with the byte length of the `SourceString` parameter, and decrementing it by two. The bit length reported by the resolved version of the `SourceString` parameter, as far as I understand it correctly, does not include the two NULL bytes, hence when decrementing it the last letter is lost.

As an example,

```
python3 analysis/ioctlance.py -i 0x80102040 -o ../LOLDrivers/drivers/1caf5070493459ba029d988dbb2c7422.bin
```
is returning `\Device\EverestDrive` as device, while `\Device\EverestDriver` should be the correct one.