### PR TITLE
Read/Write detection refactoring

### DIFF
--- a/analysis/breakpoints.py
+++ b/analysis/breakpoints.py
@@ -18,117 +18,30 @@ def b_mem_write_DriverStartIo(state):
     globals.basic_info['DriverStartIo'] = hex(globals.DriverStartIo)
     utils.print_info(f'DriverStartIo: {hex(globals.DriverStartIo)}')
 
-def b_mem_read(state):
-    utils.print_debug(f'mem_read {state}, {state.inspect.mem_read_address}, {state.inspect.mem_read_expr}, {state.inspect.mem_read_length}, {state.inspect.mem_read_condition}')
+def b_mem_read(state: angr.SimState):
+    target_base = utils.get_base_address(state.inspect.mem_read_address)
+    utils.print_debug(f'mem_read {state}, {state.inspect.mem_read_address}, {target_base}, {state.inspect.mem_read_expr}, {state.inspect.mem_read_length}, {state.inspect.mem_read_condition}')
+
+    # First we check for an ARW vulnerability. If we cannot find one there, we check for NPD
+    if not utils.check_arw_vuln(state, state.inspect.mem_read_address, False):
+        utils.check_npd_vuln(state, state.inspect.mem_read_address, False)
     
-    # Iterate all target buffers.
-    for target in globals.NPD_TARGETS:
-        if target in str(state.inspect.mem_read_address):
-            asts = [i for i in state.inspect.mem_read_address.children_asts()]
-            target_base = asts[0] if len(asts) > 1 else state.inspect.mem_read_address
-            vars = state.inspect.mem_read_address.variables
+    # If we are reading at an offset of a user-provided buffer, we need to one-time create a symbolic space that represents that space
+    # In this way we can later see if we are reading from an address obtained by dereferencing this space (a tainted address)
+    if utils.tainted_buffer(target_base):
+        utils.symbolyze_buffer(state, target_base)
 
-            if str(target_base) not in state.globals['tainted_ProbeForRead'] and str(target_base) not in state.globals['tainted_ProbeForWrite'] and len(vars) == 1:
-                # Add constraints to test whether the pointer is null or not.
-                tmp_state = state.copy()
-                if target == 'SystemBuffer':
-                    if '*' in str(state.inspect.mem_read_address):
-                        # If SystemBuffer is a pointer, check whether it is controllable.
-                        tmp_state.solver.add(tmp_state.inspect.mem_read_address == 0x87)
-                        if tmp_state.satisfiable() and not str(target_base) in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('read/write controllable address', 'read', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                    else:
-                        # If SystemBuffer is not a pointer, check whether it can be null.
-                        tmp_state.solver.add(globals.SystemBuffer == 0)
-                        tmp_state.solver.add(globals.InputBufferLength == 0)
-                        tmp_state.solver.add(globals.OutputBufferLength == 0)
-                        if tmp_state.satisfiable() and str(target_base) not in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('null pointer dereference - input buffer', 'read input buffer', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                elif target == 'Type3InputBuffer' or target == 'UserBuffer':
-                    # If Type3InputBuffer or UserBuffer is a pointer, check whether it is controllable.
-                    if target == 'Type3InputBuffer':
-                        tmp_state.solver.add(globals.Type3InputBuffer == 0x87)
-                    elif target == 'UserBuffer':
-                        tmp_state.solver.add(globals.UserBuffer == 0x87)
+def b_mem_write(state: angr.SimState):
+    target_base = utils.get_base_address(state.inspect.mem_write_address)
+    utils.print_debug(f'mem_write {state}, {state.inspect.mem_write_address}, {target_base}, {state.inspect.mem_write_expr}, {state.inspect.mem_write_length}, {state.inspect.mem_write_condition}')
 
-                    if tmp_state.satisfiable() and not str(target_base) in state.globals['tainted_MmIsAddressValid']:
-                        utils.print_vuln('read/write controllable address', 'read', state, {}, {'read from': str(state.inspect.mem_read_address)})
-                else:
-                    # Only detect the allocated memory in case of false positive.
-                    if '+' in str(tmp_state.inspect.mem_read_address):
-                        return
-                    tmp_state.solver.add(tmp_state.inspect.mem_read_address == 0)
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('null pointer dereference - allocated memory', 'read allocated memory', state, {}, {'read from': str(state.inspect.mem_read_address)})
-
-            # We symbolize the address of the tainted buffer because we want to detect the vulnerability when the driver reads/writes to/from the buffer.
-            if utils.tainted_buffer(target_base) and str(target_base) not in state.globals:
-                tmp_state = state.copy()
-                tmp_state.solver.add(target_base == globals.FIRST_ADDR)
-                if not tmp_state.satisfiable():
-                    break
-
-                state.globals[str(target_base)] = True
-                mem = claripy.BVS(f'*{str(target_base)}', 8 * 0x200).reversed
-                addr = utils.next_base_addr()
-                state.solver.add(target_base == addr)
-                state.memory.store(addr, mem, 0x200, disable_actions=True, inspect=False)
-
-def b_mem_write(state):
-    utils.print_debug(f'mem_write {state}, {state.inspect.mem_write_address}, {state.inspect.mem_write_expr}, {state.inspect.mem_write_length}, {state.inspect.mem_write_condition}')
-
-    # Iterate all target buffers.
-    for target in globals.NPD_TARGETS:
-        if target in str(state.inspect.mem_write_address):
-            asts = [i for i in state.inspect.mem_write_address.children_asts()]
-            target_base = asts[0] if len(asts) > 1 else state.inspect.mem_write_address
-            vars = state.inspect.mem_write_address.variables
-
-            if str(target_base) not in state.globals['tainted_ProbeForRead'] and str(target_base) not in state.globals['tainted_ProbeForWrite'] and len(vars) == 1:
-                # Add constraints to test whether the pointer is null or not.
-                tmp_state = state.copy()
-                if target == 'SystemBuffer':
-                    if '*' in str(state.inspect.mem_write_address):
-                        # If SystemBuffer is a pointer, check whether it is controllable.
-                        tmp_state.solver.add(tmp_state.inspect.mem_write_address == 0x87)
-                        if tmp_state.satisfiable():
-                            utils.print_vuln('read/write controllable address', 'write', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                    else:
-                        # If SystemBuffer is not a pointer, check whether it can be null.
-                        tmp_state.solver.add(globals.SystemBuffer == 0)
-                        tmp_state.solver.add(globals.InputBufferLength == 0)
-                        tmp_state.solver.add(globals.OutputBufferLength == 0)
-                        if tmp_state.satisfiable() and str(target_base) not in state.globals['tainted_MmIsAddressValid']:
-                            utils.print_vuln('null pointer dereference - input buffer', 'write input buffer', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                elif target == 'Type3InputBuffer' or target == 'UserBuffer':
-                    # If Type3InputBuffer or UserBuffer is a pointer, check whether it is controllable.
-                    if target == 'Type3InputBuffer':
-                        tmp_state.solver.add(globals.Type3InputBuffer == 0x87)
-                    elif target == 'UserBuffer':
-                        tmp_state.solver.add(globals.UserBuffer == 0x87)
-
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('read/write controllable address', 'write', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                else:
-                    # Only detect the allocated memory in case of false positive.
-                    if '+' in str(tmp_state.inspect.mem_write_address):
-                        return
-                    tmp_state.solver.add(tmp_state.inspect.mem_write_address == 0)
-                    if tmp_state.satisfiable():
-                        utils.print_vuln('null pointer dereference - allocated memory', 'write allocated memory', state, {}, {'write to': str(state.inspect.mem_write_address)})
-                
-            # We symbolize the address of the tainted buffer because we want to detect the vulnerability when the driver reads/writes to/from the buffer.
-            if utils.tainted_buffer(target_base) and str(target_base) not in state.globals:
-                tmp_state = state.copy()
-                tmp_state.solver.add(target_base == globals.FIRST_ADDR)
-                if not tmp_state.satisfiable():
-                    break
-                
-                state.globals[str(target_base)] = True
-                mem = claripy.BVS(f'*{str(target_base)}', 8 * 0x200).reversed
-                addr = utils.next_base_addr()
-                state.solver.add(target_base == addr)
-                state.memory.store(addr, mem, 0x200, disable_actions=True, inspect=False)
+    # First we check for an ARW vulnerability. If we cannot find one there, we check for NPD
+    if not utils.check_arw_vuln(state, state.inspect.mem_write_address, True):
+        utils.check_npd_vuln(state, state.inspect.mem_write_address, True)
+    
+    # Same as b_mem_read prologue
+    if utils.tainted_buffer(target_base):
+        utils.symbolyze_buffer(state, target_base)
 
 def b_address_concretization_before(state):
     utils.print_debug(f'address_concretization_before_hook: {state}\n\taddress_concretization_strategy: {state.inspect.address_concretization_strategy}\n\taddress_concretization_action: {state.inspect.address_concretization_action}\n\taddress_concretization_memory: {state.inspect.address_concretization_memory}\n\taddress_concretization_expr: {state.inspect.address_concretization_expr}\n\taddress_concretization_add_constraints: {state.inspect.address_concretization_add_constraints}\n\taddress_concretization_result: {state.inspect.address_concretization_result}\n')

--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -191,32 +191,25 @@ class HookProbeForRead(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForRead.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if 'tainted_ProbeForRead' in self.state.globals and utils.tainted_buffer(Address):
-                asts = [i for i in Address.children_asts()]
-                target_base = asts[0] if len(asts) > 1 else Address
-
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_ProbeForRead'] += (str(target_base), )
+            base_address = utils.get_base_address(Address)
+            if ('tainted_ProbeForRead' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_ProbeForRead'] += (str(base_address), )
 
 class HookProbeForWrite(angr.SimProcedure):
     # Tag the tainted buffer that is validated with ProbeForWrite.
     def run(self, Address, Length, Alignment):
         if globals.phase == 2:
-            if 'tainted_ProbeForWrite' in self.state.globals and utils.tainted_buffer(Address):
-                asts = [i for i in Address.recursive_children_asts]
-                target_base = asts[0] if len(asts) > 1 else Address
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_ProbeForWrite'] += (str(target_base), )
+            base_address = utils.get_base_address(Address)
+            if ('tainted_ProbeForWrite' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_ProbeForWrite'] += (str(base_address), )
 
 class HookMmIsAddressValid(angr.SimProcedure):
     # Tag the tainted buffer that is validated with MmIsAddressValid.
     def run(self, VirtualAddress):
         if globals.phase == 2:
-            if 'tainted_MmIsAddressValid' in self.state.globals and utils.tainted_buffer(VirtualAddress):
-                asts = [i for i in VirtualAddress.recursive_children_asts]
-                target_base = asts[0] if len(asts) > 1 else VirtualAddress
-                ret_addr = hex(self.state.callstack.ret_addr)
-                self.state.globals['tainted_MmIsAddressValid'] += (str(target_base), )
+            base_address = utils.get_base_address(VirtualAddress)
+            if ('tainted_MmIsAddressValid' in self.state.globals) and utils.tainted_buffer(base_address):
+                self.state.globals['tainted_MmIsAddressValid'] += (str(base_address), )
         return 1
 
 class HookZwOpenSection(angr.SimProcedure):
@@ -457,16 +450,9 @@ class HookZwTerminateProcess(angr.SimProcedure):
 class HookMemcpy(angr.SimProcedure):
     def run(self, dest, src, size):
         ret_addr = hex(self.state.callstack.ret_addr)
-        dest_asts = [i for i in dest.children_asts()]
-        dest_base = dest_asts[0] if len(dest_asts) > 1 else dest
-        dest_vars = dest.variables
-
-        src_asts = [i for i in src.children_asts()]
-        src_base = src_asts[0] if len(src_asts) > 1 else src
-        src_vars = src.variables
 
         # Check whether the src or dest address can be controlled.
-        if ('*' in str(dest) and utils.tainted_buffer(dest) and str(dest_base) not in self.state.globals['tainted_ProbeForWrite'] and len(dest_vars) == 1) or ('*' in str(src) and utils.tainted_buffer(src) and str(src_base) not in self.state.globals['tainted_ProbeForRead'] and len(src_vars) == 1):
+        if utils.tainted_memory_address(self.state, dest) or utils.tainted_memory_address(self.state, src):
             utils.print_vuln('dest or src controllable', 'memcpy/memmove', self.state, {'dest': str(dest), 'src': str(src), 'size': str(size)}, {'return address': ret_addr})
 
         # Buffer overflow detected if the size can be controlled and the destination address is not symbolic to avoid false positive.

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,4 +1,6 @@
 import collections
+import angr
+import claripy
 import cle
 from cle.backends.pe.relocation.generic import DllImport
 from typing import Optional
@@ -7,10 +9,10 @@ import sys
 import json
 
 def tainted_buffer(s):
-    # The tainted buffer contains only one symbolic variable.
-    if len(s.variables) != 1:
+    # Buffer must be a BitVector and must contain only one symbolic variable
+    if (not isinstance(s, claripy.ast.bv.BV)) or (len(s.variables) != 1):
         return ''
-    
+        
     # Check the tainted symbolic variable.
     s = str(s)
     if 'SystemBuffer' in s:
@@ -25,6 +27,104 @@ def tainted_buffer(s):
         return 'OutputBufferLength'
     else:
         return ''
+
+def user_memory_address(state: angr.SimState, address) -> bool:
+    ''' Returns true if a memory address is contained in a user-provided buffer '''
+    
+    # Address must evaluate to one symbolic variable.
+    if (not isinstance(address, claripy.ast.bv.BV)) or (len(address.variables) != 1):
+        return False
+    
+    addr_base = get_base_address(address)
+    # Base address must be tainted and must be a dereference
+    if  ((not tainted_buffer(addr_base)) or
+        (len(addr_base.args) <= 0) or
+        (not isinstance(addr_base.args[0], str)) or
+        (not addr_base.args[0].startswith("*<"))):
+        return False
+    
+    return True
+
+def tainted_memory_address(state: angr.SimState, address) -> bool:
+    ''' Returns true if a memory address is user-provided and has not been validated through functions like ProbeForWrite, ProbeForWrite, MmIsAddressValid '''
+    base_str = str(get_base_address(address))
+    
+    # Address must evaluate to one symbolic variable.
+    # With METHOD_NEITHER ioctl communication, kernel performs no checks on the input buffers. Everything is delegated to the driver
+    tainted_direct_input = 'Type3InputBuffer' in base_str
+    # In the case of METHOD_BUFFERED, the UserBuffer pointer is copied to the IRP but there is a PROBE before
+    tainted_direct_output = ('UserBuffer' in base_str) and state.solver.eval((globals.IoControlCode & 0x3) == 0x3)
+    if (not tainted_direct_input) and(not tainted_direct_output) and not user_memory_address(state, address):
+        return False
+    
+    # Let's just check if the address has not been probed
+    if ((base_str in state.globals['tainted_ProbeForWrite']) or 
+        (base_str in state.globals['tainted_ProbeForRead'])):
+        return False
+
+    return True
+
+def get_base_address(address):
+    if not isinstance(address, claripy.ast.bv.BV):
+        return address
+    else:
+        symbolic_leafs = [i for i in address.leaf_asts() if i.symbolic]
+        return symbolic_leafs[0] if len(symbolic_leafs) == 1 else address
+    
+def symbolyze_buffer(state: angr.SimState, symb_address: claripy.ast.bv.BV):
+    symb_address_str = str(symb_address)
+    if symb_address_str not in state.globals:
+        addr = next_base_addr()
+        tmp_state = state.copy()
+        tmp_state.solver.add(symb_address == addr)
+        if not tmp_state.satisfiable():
+            return
+
+        state.globals[symb_address_str] = True
+        mem = claripy.BVS(f'*{symb_address_str}', 8 * 0x200).reversed
+        
+        state.solver.add(symb_address == addr)
+        state.memory.store(addr, mem, 0x200, disable_actions=True, inspect=False)
+
+def check_npd_vuln(state: angr.SimState, address, write: bool):
+    '''Checks if a specific address in a specific state is a Null Pointer Dereference target '''
+
+    address_str = str(address)
+    # Only checks for NPD targets in top-level buffer pointers
+    address_is_npd_target = any(target in address_str for target in globals.NPD_TARGETS) and ('*' not in address_str)
+    if not address_is_npd_target:
+        return
+    
+    tmp_state = state.copy()
+    tmp_state.solver.add(address == 0)
+    if not tmp_state.satisfiable():
+        return
+    
+    operation = "write" if write else "read"
+    operation_other = "write to" if write else "read from"
+    if tainted_buffer(address):
+        print_vuln('null pointer dereference - input buffer', f'{operation} input buffer', state, {}, {operation_other: address_str})
+    else:
+        print_vuln('null pointer dereference - allocated memory', f'{operation} allocated memory', state, {}, {operation_other: address_str})
+
+def check_arw_vuln(state: angr.SimState, address, write: bool) -> bool:
+    '''Checks if a specific address in a specific state is an arbitrary read/write target '''
+
+    address_str = str(address)
+    if not tainted_memory_address(state, address):
+        return False
+    
+    # Let's try to assign a concrete value to our address to see if 
+    # the constraints are still valid
+    tmp_state = state.copy()
+    tmp_state.solver.add(address == 0x10000)
+    if not tmp_state.satisfiable():
+        return False
+
+    operation = "write" if write else "read"
+    operation_other = "write to" if write else "read from"
+    print_vuln('read/write controllable address', operation, tmp_state, {}, {operation_other: address_str})
+    return True
 
 def analyze_ObjectAttributes(func_name, state, ObjectAttributes):
     ObjectName = state.mem[ObjectAttributes].struct._OBJECT_ATTRIBUTES.ObjectName.resolved

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -95,6 +95,11 @@ def check_npd_vuln(state: angr.SimState, address, write: bool):
     if not address_is_npd_target:
         return
     
+    # MmIsAddressValid will return False for NULL pointers
+    base_address = get_base_address(address)
+    if (base_address in state.globals['tainted_MmIsAddressValid']): 
+        return 
+    
     tmp_state = state.copy()
     tmp_state.solver.add(address == 0)
     if not tmp_state.satisfiable():


### PR DESCRIPTION
From #9 

We'd like to propose a refactoring for the arbitrary R/W detection mechanism. Since the code of `b_mem_read` and `b_mem_write` is pretty similar, we've merged the implementation into three new utility functions:
- `check_arw_vuln()`: checks for an arbitrary read/write of a specific address
- `check_npd_vuln()`: checks for a null pointer dereference of a specific address
- `symbolyze_buffer()`: creates a symbolic region of memory, which is what happens at the end of b_mem_read and b_mem_write

We also created a new get_base_address() function to substitute all code blocks that were used to calculate a base address from a symbolic expression

The refactor also changes these implementation details:
- Taint on `UserBuffer` in the new function `tainted_memory_address()` is considered valid only when the IOCTL method is METHOD_NEITHER
- Old code is using `children_asts()` to obtain the base address of an expression; we propose to use `leaf_asts()` which seems more robust and provides more accurate results
- In `check_arw_vuln()`, address constraint now uses a larger value, but probably does not impact the accuracy of the results

Here are some specific tests that we carried out using the LOLDrivers repository, where the output is different with respect to the main code:

## Taint on `UserBuffer` 
```
python3 analysis/ioctlance.py -i 0x80002000 -o ../LOLDrivers/drivers/31eca8c0b32135850d5a50aee11fec87.bin
python3 analysis/ioctlance.py -i 0xa00068cc -o ../LOLDrivers/drivers/29b1ddc69e89b160cc3722e5e0738fd8.bin
```
For these two drivers, ioctlance now DOES NOT report a taint for `UserBuffer`, given the `METHOD_BUFFERED` of the ioctls 

## New ARW detection
Current implementation detects some new ARWs.
```
python3 analysis/ioctlance.py -i 0x22e043 -o ../LOLDrivers/drivers/978cd6d9666627842340ef774fd9e2ac.bin
```
outputs an arbitrary read and an arbitrary write that were not detected before