### PR TITLE
Update of the MmGetSystemRoutineAddress hook function

### DIFF
--- a/analysis/hooks.py
+++ b/analysis/hooks.py
@@ -172,6 +172,8 @@ class HookMmGetSystemRoutineAddress(angr.SimProcedure):
 
         hooks = {
             "ZwQueryInformationProcess": HookZwQueryInformationProcess,
+            "RtlQueryRegistryValuesEx": HookRtlQueryRegistryValues,
+            "RtlQueryRegistryValues": HookRtlQueryRegistryValues,
         }
 
         for name, proc in hooks.items():


### PR DESCRIPTION
Update of the hook *MmGetSystemRoutineAddress*in order to manage when this function is used with the *RtlQueryRegistryValues* and *RtlQueryRegistryValuesEx* to associated both to our new hook of the function *RtlQueryRegistryValues*.